### PR TITLE
Making the API endpoint selection dynamic

### DIFF
--- a/OrionConnect_Api_Sample/App.config
+++ b/OrionConnect_Api_Sample/App.config
@@ -2,11 +2,16 @@
 <configuration>
   <appSettings>
     <!-- TEST URL-->
+    <!--
     <add key="OrionApiUrl" value="https://testapi.orionadvisor.com/api/v1/"/>
     <add key="OrionConnectUrl" value="https://testapi.orionadvisor.com/OrionConnectApp/integration.html"/>
+    <add key="OrionEnvironment" value="Test" />
+    -->
     
     <!-- PRODUCTION URL -->
-    <!--<add key="OrionApiUrl" value="https://api.orionadvisor.com/api/v1/"/> -->
+    <add key="OrionApiUrl" value="https://api.orionadvisor.com/api/v1/"/>
+    <add key="OrionConnectUrl" value="https://api.orionadvisor.com/OrionConnectApp/integration.html"/>
+    <add key="OrionEnvironment" value="Production" />
   </appSettings>
   <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />

--- a/OrionConnect_Api_Sample/Form1.cs
+++ b/OrionConnect_Api_Sample/Form1.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Configuration;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
@@ -48,8 +49,10 @@ namespace OrionConnect_Api_Sample
 
             lblLoginStatus.Text = "";
             try {
+                var env = (OrionEnvironment)Enum.Parse(typeof(OrionEnvironment), ConfigurationManager.AppSettings["OrionEnvironment"]);
+
                 // use the "stored" token, in this case it is just the token in the text box.
-                if( OrionApi.Authenticate( txtAuthToken.Text, OrionEnvironment.Test ) ) {
+                if( OrionApi.Authenticate( txtAuthToken.Text,  env ) ) {
                     MessageBox.Show( "The token is valid." );
                 } else
                 {
@@ -57,7 +60,7 @@ namespace OrionConnect_Api_Sample
 
                     var login = new frmLogin();
                     if( login.ShowDialog( ) == DialogResult.OK ) {
-                        OrionApi.Authenticate( login.UserName, login.Password, OrionEnvironment.Test );
+                        OrionApi.Authenticate( login.UserName, login.Password, env);
                         this.setStatus( "Authenticate", "/Security/Token" );
                     } else {
                         return;


### PR DESCRIPTION
Making the API endpoint selection dynamic through app.config so this test app can be used with the real API endpoint as well as the test API endpoint.
